### PR TITLE
Fix hidden_unset error

### DIFF
--- a/autoload/fila/action.vim
+++ b/autoload/fila/action.vim
@@ -288,6 +288,7 @@ endfunction
 function! s:hidden_unset(range, params, helper) abort
   let node = a:helper.get_cursor_node(a:range)
   let winid = win_getid()
+  call cursor(1, 1)
   call a:helper.set_hidden(0)
   return a:helper.redraw()
         \.then({ h -> h.cursor_node(winid, node) })
@@ -297,6 +298,9 @@ endfunction
 function! s:hidden_toggle(range, params, helper) abort
   let node = a:helper.get_cursor_node(a:range)
   let winid = win_getid()
+  if a:helper.get_hidden()
+    call cursor(1, 1)
+  endif
   call a:helper.set_hidden(!a:helper.get_hidden())
   return a:helper.redraw()
         \.then({ h -> h.cursor_node(winid, node) })


### PR DESCRIPTION
Error occurred in fila-action-hidden-toggle

```
function <SNR>191_action_call_safe[4]..<SNR>183_call[4]..<SNR>190_hidden_toggle[4]..<SNR>181_redraw の処理中にエラーが検出されました:
行   10:
Cursor position outside buffer
```

Move cursor before fila-action-hidden-unset