### PR TITLE
Add -reveal={path} option and fix behavior of drawer

### DIFF
--- a/autoload/fila.vim
+++ b/autoload/fila.vim
@@ -3,16 +3,22 @@ let s:Flag = vital#fila#import('App.Flag')
 
 function! fila#command(mods, qargs) abort
   let [options, remains] = s:Flag.parse(s:Flag.split(a:qargs))
-  let bufname = s:init_bufname(remains)
-  let options.mods = a:mods
-  if get(options, 'drawer')
-    return fila#viewer#drawer#open(bufname, options)
+  call s:open(s:bufname(remains), extend(options, {
+        \   'mods': a:mods,
+        \ }))
+        \.then({ -> s:reveal(expand(get(options, 'reveal', ''))) })
+        \.catch({ e -> fila#lib#error#handle(e) })
+endfunction
+
+function! s:open(bufname, options) abort
+  if get(a:options, 'drawer')
+    return fila#viewer#drawer#open(a:bufname, a:options)
   else
-    return fila#viewer#open(bufname, options)
+    return fila#viewer#open(a:bufname, a:options)
   endif
 endfunction
 
-function! s:init_bufname(args) abort
+function! s:bufname(args) abort
   let url = len(a:args) ? remove(a:args, 0) : s:smart_url()
   let url = url =~# '^[^:]\+://' ? url : 'file://' . fnamemodify(url, ':p')
   return 'fila://' . fnamemodify(url, ':gs?\\?/?')
@@ -24,6 +30,18 @@ function! s:smart_url() abort
   else
     return getcwd()
   endif
+endfunction
+
+function! s:reveal(path) abort
+  if empty(a:path)
+    return
+  endif
+  let winid = win_getid()
+  let helper = fila#node#helper#new()
+  let key = helper.keyof(a:path)
+  call helper.reveal(key)
+        \.then({ h -> h.redraw() })
+        \.then({ h -> h.cursor(winid, key, 0, 1) })
 endfunction
 
 call s:Config.config(expand('<sfile>:p'), {

--- a/autoload/fila/node.vim
+++ b/autoload/fila/node.vim
@@ -121,6 +121,17 @@ function! fila#node#collapse(key, nodes, comparator) abort
   return p
 endfunction
 
+function! fila#node#reveal(key, nodes, comparator) abort
+  let n = len(a:nodes[0].key) - 1
+  let k = copy(a:key)
+  let ks = []
+  while len(k) - 1 > n
+    call add(ks, copy(k))
+    call remove(k, -1)
+  endwhile
+  return s:expand_recursively(ks, a:nodes, a:comparator)
+endfunction
+
 function! s:uniq(nodes) abort
   return uniq(a:nodes, { a, b -> a.key != b.key })
 endfunction
@@ -128,6 +139,16 @@ endfunction
 function! s:extend(key, nodes, new_nodes) abort
   let index = fila#node#index(a:key, a:nodes)
   return index is# -1 ? a:nodes : extend(a:nodes, a:new_nodes, index + 1)
+endfunction
+
+function! s:expand_recursively(keys, nodes, comparator) abort
+  return fila#node#expand(a:keys[-1], a:nodes, a:comparator)
+        \.then({ v -> s:Lambda.pass(v, remove(a:keys, -1)) })
+        \.then({ v -> s:Lambda.if(
+        \   len(a:keys) > 1,
+        \   { -> s:expand_recursively(a:keys, v, a:comparator) },
+        \   { -> v },
+        \ )})
 endfunction
 
 let g:fila#node#STATUS_COLLAPSED = s:STATUS_COLLAPSED

--- a/autoload/fila/node/helper.vim
+++ b/autoload/fila/node/helper.vim
@@ -43,6 +43,7 @@ function! fila#node#helper#new(...) abort
         \ 'expand_node': funcref('s:expand_node'),
         \ 'collapse_node': funcref('s:collapse_node'),
         \ 'reveal_node': funcref('s:reveal_node'),
+        \ 'keyof': funcref('s:keyof'),
         \}
   return extend(copy(s:helper), {
         \ 'bufnr': bufnr,
@@ -260,6 +261,11 @@ endfunction
 
 function! s:reveal_node(node) abort dict
   return self.reveal(a:node.key)
+endfunction
+
+function! s:keyof(path) abort dict
+  let root = self.get_root_node()
+  return root.keyof(a:path)
 endfunction
 
 

--- a/autoload/fila/node/helper.vim
+++ b/autoload/fila/node/helper.vim
@@ -36,11 +36,13 @@ function! fila#node#helper#new(...) abort
         \ 'reload': funcref('s:reload'),
         \ 'expand': funcref('s:expand'),
         \ 'collapse': funcref('s:collapse'),
+        \ 'reveal': funcref('s:reveal'),
         \ 'enter_node': funcref('s:enter_node'),
         \ 'cursor_node': funcref('s:cursor_node'),
         \ 'reload_node': funcref('s:reload_node'),
         \ 'expand_node': funcref('s:expand_node'),
         \ 'collapse_node': funcref('s:collapse_node'),
+        \ 'reveal_node': funcref('s:reveal_node'),
         \}
   return extend(copy(s:helper), {
         \ 'bufnr': bufnr,
@@ -220,6 +222,13 @@ function! s:collapse(key) abort dict
         \.then({ -> self })
 endfunction
 
+function! s:reveal(key) abort dict
+  let nodes = self.get_nodes()
+  return fila#node#reveal(a:key, nodes, self.comparator.compare)
+        \.then({ v -> self.set_nodes(v)})
+        \.then({ -> self })
+endfunction
+
 function! s:enter_node(node) abort dict
   let marks = self.get_marks()
   let hidden = self.get_hidden()
@@ -247,6 +256,10 @@ endfunction
 
 function! s:collapse_node(node) abort dict
   return self.collapse(a:node.key)
+endfunction
+
+function! s:reveal_node(node) abort dict
+  return self.reveal(a:node.key)
 endfunction
 
 

--- a/autoload/fila/node/helper.vim
+++ b/autoload/fila/node/helper.vim
@@ -223,7 +223,7 @@ endfunction
 function! s:enter_node(node) abort dict
   let marks = self.get_marks()
   let hidden = self.get_hidden()
-  return fila#lib#buffer#open(a:node.bufname, {
+  return fila#viewer#open(a:node.bufname, {
         \ 'opener': 'edit',
         \ 'locator': 0,
         \ 'notifier': 1,

--- a/autoload/fila/node/helper.vim
+++ b/autoload/fila/node/helper.vim
@@ -228,7 +228,7 @@ function! s:enter_node(node) abort dict
         \ 'locator': 0,
         \ 'notifier': 1,
         \})
-        \.then({ c -> fila#node#helper#new(c.bufnr) })
+        \.then({ -> fila#node#helper#new() })
 endfunction
 
 function! s:cursor_node(winid, node, ...) abort dict

--- a/autoload/fila/scheme/file.vim
+++ b/autoload/fila/scheme/file.vim
@@ -2,13 +2,19 @@ let s:Lambda = vital#fila#import('Lambda')
 let s:Promise = vital#fila#import('Async.Promise')
 let s:Process = vital#fila#import('Async.Promise.Process')
 
+function! fila#scheme#file#root(path) abort
+  let root = s:node(simplify(a:path))
+  let root.keyof = funcref('s:keyof')
+  let root.parent = s:node(simplify(fnamemodify(a:path, ':p:h:h')))
+  return root
+endfunction
+
 function! fila#scheme#file#node(path) abort
   return s:node(simplify(a:path))
 endfunction
 
 function! s:node(path) abort
   let path = fnamemodify(a:path, ':p')
-  let key = split(fnamemodify(path, ':gs?\\?/?'), '/')
   if isdirectory(path)
     let options = {
           \ '__path': path,
@@ -23,7 +29,11 @@ function! s:node(path) abort
           \ 'hidden': s:is_hidden(path),
           \}
   endif
-  return fila#node#new(key, options)
+  return fila#node#new(s:keyof(path), options)
+endfunction
+
+function! s:keyof(path) abort
+  return split(fnamemodify(simplify(a:path), ':p:gs?\\?/?'), '/')
 endfunction
 
 if executable('ls')

--- a/autoload/fila/viewer.vim
+++ b/autoload/fila/viewer.vim
@@ -7,8 +7,17 @@ function! fila#viewer#open(bufname, options) abort
         \ 'opener': g:fila#viewer#opener,
         \}, a:options)
   let options.notifier = 1
-  return fila#lib#buffer#open(a:bufname, options)
+  let bufname = a:bufname =~# '#[a-f0-9]\+$'
+        \ ? a:bufname
+        \ : a:bufname . '#' . sha256(localtime())
+  return fila#lib#buffer#open(bufname, options)
         \.catch({ e -> fila#lib#error#handle(e) })
+endfunction
+
+function! fila#viewer#bufname(expr) abort
+  let bufname = expand(a:expr)
+  let bufname = matchstr(bufname, '^.*\ze#[a-f0-9]\+$')
+  return bufname
 endfunction
 
 function! fila#viewer#BufReadCmd(factory) abort

--- a/autoload/fila/viewer/drawer.vim
+++ b/autoload/fila/viewer/drawer.vim
@@ -26,7 +26,7 @@ function! fila#viewer#drawer#open(bufname, options) abort
           \ 'opener': printf('topleft %dvsplit', options.width),
           \ 'cmdarg': '+setlocal\ winfixwidth',
           \})
-          \.then({ c -> s:set_winid(bufwinid(c.bufnr)) })
+          \.then({ -> s:set_winid(win_getid()) })
           \.catch({ e -> fila#lib#error#handle(e) })
   endif
 endfunction

--- a/plugin/fila/file.vim
+++ b/plugin/fila/file.vim
@@ -4,7 +4,8 @@ endif
 let g:fila_file_loaded = 1
 
 function! s:BufReadCmd() abort
-  let path = matchstr(expand('<afile>'), 'fila://\%(file://\)\?\zs.*')
+  let bufname = fila#viewer#bufname('<afile>')
+  let path = matchstr(bufname, 'fila://\%(file://\)\?\zs.*')
   let root = fila#scheme#file#node(path)
   let root.parent = fila#scheme#file#node(fnamemodify(path, ':p:h:h'))
   call fila#viewer#BufReadCmd({ -> root })

--- a/plugin/fila/file.vim
+++ b/plugin/fila/file.vim
@@ -6,8 +6,7 @@ let g:fila_file_loaded = 1
 function! s:BufReadCmd() abort
   let bufname = fila#viewer#bufname('<afile>')
   let path = matchstr(bufname, 'fila://\%(file://\)\?\zs.*')
-  let root = fila#scheme#file#node(path)
-  let root.parent = fila#scheme#file#node(fnamemodify(path, ':p:h:h'))
+  let root = fila#scheme#file#root(path)
   call fila#viewer#BufReadCmd({ -> root })
 endfunction
 

--- a/test/fila/node.vimspec
+++ b/test/fila/node.vimspec
@@ -493,4 +493,58 @@ Describe fila#node
       Assert False(fila#node#is_expanded(nodes[1]))
     End
   End
+
+  Describe reveal()
+    It rejects when no node for a given key is found
+      let nodes = [
+            \ fila#node#new([], {}),
+            \ fila#node#new(['Users'], {
+            \   'children': [
+            \     fila#node#new(['Users', 'Alice'], {
+            \       'children': [
+            \         fila#node#new(['Users', 'Alice', 'A'], {}),
+            \         fila#node#new(['Users', 'Alice', 'B'], {}),
+            \         fila#node#new(['Users', 'Alice', 'C'], {}),
+            \       ],
+            \     }),
+            \     fila#node#new(['Users', 'John'], {
+            \       'children': [
+            \         fila#node#new(['Users', 'John', 'A'], {}),
+            \         fila#node#new(['Users', 'John', 'B'], {}),
+            \         fila#node#new(['Users', 'John', 'C'], {}),
+            \       ],
+            \     }),
+            \     fila#node#new(['Users', 'Peter'], {
+            \       'children': [
+            \         fila#node#new(['Users', 'Peter', 'A'], {}),
+            \         fila#node#new(['Users', 'Peter', 'B'], {}),
+            \         fila#node#new(['Users', 'Peter', 'C'], {}),
+            \       ],
+            \     }),
+            \   ],
+            \ }),
+            \ fila#node#new(['Library'], {
+            \   'children': [
+            \     fila#node#new(['Library', 'Hello'], {}),
+            \     fila#node#new(['Library', 'World'], {}),
+            \   ],
+            \ }),
+            \]
+      let p = fila#node#reveal(['Users', 'John', 'B'], nodes, comparator.compare)
+      Assert True(Promise.is_promise(p))
+      let [r, e] = Promise.wait(p)
+      Assert Equals(e, v:null)
+      Assert Equals(map(copy(r), { -> v:val.key }), [
+            \ [],
+            \ ['Users'],
+            \ ['Users', 'Alice'],
+            \ ['Users', 'John'],
+            \ ['Users', 'John', 'A'],
+            \ ['Users', 'John', 'B'],
+            \ ['Users', 'John', 'C'],
+            \ ['Users', 'Peter'],
+            \ ['Library'],
+            \])
+    End
+  End
 End


### PR DESCRIPTION
This PR

- Remove invalid calls when "enter" action is called or drawer is opened
- Properly initialize the buffer on "enter/leave" actions
- Add unique suffix to make the buffer always fresh.
    - Fix buffer synchronous issue
    - Fix #12 
- Add `-reveal={path}` option to reveal a specified path

### Usage of -reveal

Open a fila buffer of the current working directory (e.g. `fila.vim`) with the current buffer 
 (e.g. `fila.vim/autoload/fila/node/comparator/default.vim`) revealed.

```
:Fila . -reveal=%
```

<img width="1049" alt="alacritty 2019-03-01 00-34-13" src="https://user-images.githubusercontent.com/546312/53577982-01b36280-3bba-11e9-974d-e461878c9299.png">


Or with drawer style

```
:Fila . -drawer -reveal=%
```

<img width="1049" alt="alacritty 2019-03-01 00-37-16" src="https://user-images.githubusercontent.com/546312/53578113-4e973900-3bba-11e9-9573-363d3c935978.png">

### Tips

When you use `:Fila . -reveal=%` in your mapping, you would noticed that the mapping does not work on a fresh new buffer.
Workaround is using `<C-r>=expand('%')<CR>` instead so that the `%` is not passed to the command.

```
nnoremap <silent> <Plug>(fila-smart-viewer) :<C-u>Fila . -reveal=<C-r>=expand('%')<CR><CR>
nnoremap <silent> <Plug>(fila-smart-drawer) :<C-u>Fila . -drawer -reveal=<C-r>=expand('%')<CR><CR>
nmap <Leader>fv <Plug>(fila-smart-viewer)
nmap <Leader>fd <Plug>(fila-smart-drawer)
```